### PR TITLE
use drone_gitlab_server variable in drone-server.env.j2

### DIFF
--- a/templates/drone-server.env.j2
+++ b/templates/drone-server.env.j2
@@ -50,7 +50,7 @@ DRONE_GITHUB_CLIENT_SECRET={{ drone_github_client_secret }}
 DRONE_GITHUB_DEBUG={{ drone_github_debug }}
 {% endif %}
 {% if drone_gitlab_client_id != "" and drone_gitlab_client_secret != "" %}
-DRONE_GITLAB_SERVER=https://gitlab.com
+DRONE_GITLAB_SERVER={{ drone_gitlab_server }}
 DRONE_GITLAB_CLIENT_ID={{ drone_gitlab_client_id }}
 DRONE_GITLAB_CLIENT_SECRET={{ drone_gitlab_client_secret }}
 DRONE_GITLAB_DEBUG={{ drone_github_debug }}


### PR DESCRIPTION
Use drone_gitlab_server variable instead of the hardcoded value of 'https://gitlab.com'